### PR TITLE
New io semantics

### DIFF
--- a/canal/global_signal.py
+++ b/canal/global_signal.py
@@ -1,10 +1,17 @@
 """Useful pass on interconnect that doesn't deal with the routing network"""
 import magma
 import mantle
+import enum
 from gemstone.common.transform import pass_signal_through, or_reduction
 from gemstone.generator.const import Const
 from gemstone.generator.from_magma import FromMagma
 from .interconnect import Interconnect
+
+
+@enum.unique
+class GlobalSignalWiring(enum.Enum):
+    Fanout = enum.auto()
+    Meso = enum.auto()
 
 
 def apply_global_fanout_wiring(interconnect: Interconnect, margin: int = 0):

--- a/canal/util.py
+++ b/canal/util.py
@@ -189,14 +189,14 @@ def connect_io(interconnect: InterconnectGraph,
             if x in range(0, x_min):
                 next_tile = interconnect[(x + 1, y)]
                 side = SwitchBoxSide.WEST
-            elif x in range(x_max, width):
+            elif x in range(x_max + 1, width):
                 next_tile = interconnect[(x - 1, y)]
                 side = SwitchBoxSide.EAST
             elif y in range(0, y_min):
                 next_tile = interconnect[(x, y + 1)]
                 side = SwitchBoxSide.NORTH
             else:
-                assert y in range(y_max, height)
+                assert y in range(y_max + 1, height)
                 next_tile = interconnect[(x, y - 1)]
                 side = SwitchBoxSide.SOUTH
             for input_port, conn in input_port_conn.items():

--- a/canal/util.py
+++ b/canal/util.py
@@ -175,8 +175,8 @@ def connect_io(interconnect: InterconnectGraph,
     width, height = interconnect.get_size()
     x_min, x_max, y_min, y_max = get_array_size(width, height, io_sides)
     # compute tiles and sides
-    for x in range(x_max):
-        for y in range(y_max):
+    for x in range(width):
+        for y in range(height):
             if x in range(x_min, x_max + 1) and \
                     y in range(y_min, y_max + 1):
                 continue

--- a/tests/test_interconnect.py
+++ b/tests/test_interconnect.py
@@ -1,16 +1,14 @@
 from hwtypes import BitVector
 from gemstone.common.dummy_core_magma import DummyCore
 from gemstone.common.testers import BasicTester
-
 from canal.checker import check_graph_isomorphic
 from canal.interconnect import *
 import tempfile
 import fault.random
 from canal.util import create_uniform_interconnect, SwitchBoxType
 from canal.global_signal import apply_global_fanout_wiring, \
-    apply_global_meso_wiring
+    apply_global_meso_wiring, GlobalSignalWiring
 import pytest
-import enum
 import filecmp
 
 
@@ -26,13 +24,6 @@ def assert_tile_coordinate(tile: Tile, x: int, y: int):
 
 def assert_coordinate(node: Node, x: int, y: int):
     assert node.x == x and node.y == y
-
-
-# add enum to make pytest more readable
-@enum.unique
-class GlobalSignalWiring(enum.Enum):
-    Fanout = enum.auto()
-    Meso = enum.auto()
 
 
 @pytest.mark.parametrize("num_tracks", [2, 4])

--- a/tests/test_special_tiles.py
+++ b/tests/test_special_tiles.py
@@ -44,6 +44,7 @@ def test_empty_switch_box():
 def test_empty_tile_util():
     chip_size = 4
     margin = 1
+    sides = IOSide.North | IOSide.East | IOSide.South | IOSide.West
     bit_widths = [1, 16]
     cores = {}
     track_length = 1
@@ -78,7 +79,7 @@ def test_empty_tile_util():
                                           f"data_out_{bit_width}b": out_conn},
                                          {track_length: num_tracks},
                                          SwitchBoxType.Disjoint,
-                                         margin=margin)
+                                         io_sides=sides)
         ics[bit_width] = ic
     interconnect = Interconnect(ics, addr_width, data_width, tile_id_width)
     interconnect.finalize()


### PR DESCRIPTION
This change is made so that we can create a CGRA with IO on one side only. This required due to the addition of global buffer and SoC.

More robust tests are at Garnet.