### PR TITLE
Poke index 0 of array[1]

### DIFF
--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -173,7 +173,7 @@ def test_sb(num_tracks: int, bit_width: int, sb_ctor,
                     tester.expect(data[j - 1][1], data[j - 1][2])
 
                 input_port, _, value = data[j]
-                tester.poke(input_port, value)
+                tester.poke(input_port[0], value)
                 tester.step(2)
 
     with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
When printing out the type of input_port with
```python
                input_port, _, value = data[j]
                print(input_port, type(input_port), _, type(_))
```
I get 
```
SB_T0_NORTH_SB_IN_B16 Array[1, Out(Bits[16])] SB_T0_SOUTH_SB_OUT_B16 In(Bits[16])
SB_T0_NORTH_SB_IN_B16 Array[1, Out(Bits[16])] SB_T0_SOUTH_SB_OUT_B16 In(Bits[16])
SB_T0_NORTH_SB_IN_B16 Array[1, Out(Bits[16])] SB_T0_SOUTH_SB_OUT_B16 In(Bits[16])
SB_T0_NORTH_SB_IN_B16 Array[1, Out(Bits[16])] SB_T0_SOUTH_SB_OUT_B16 In(Bits[16])
SB_T0_NORTH_SB_IN_B16 Array[1, Out(Bits[16])] SB_T0_EAST_SB_OUT_B16 In(Bits[16])
SB_T0_NORTH_SB_IN_B16 Array[1, Out(Bits[16])] SB_T0_EAST_SB_OUT_B16 In(Bits[16])
...
```

So I changed the code to poke the `[0]` index of the port.  In this case, fault should have given a better error message, but I think this was the actual intent? An alternative way to write it would be: `tester.poke(input_port, [value])` so the poke value is a list (to reflect the array of values being poked)