### PR TITLE
Flatten Array[1, Bits[N]] to Bits[N] in Tile interface

### DIFF
--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -50,7 +50,7 @@ class _PassThroughFromMux(Generator):
         return self._name
 
 
-def _flatten_mux(mux):
+def flatten_mux(mux):
     if mux.height != 1:
         return mux
     return _PassThroughFromMux(mux)
@@ -68,7 +68,7 @@ def create_mux(node: Node):
     else:
         name = f"WIRE_{node_name}"
     mux = MuxWrapper(height, node.width, name=name)
-    return _flatten_mux(mux)
+    return flatten_mux(mux)
 
 
 class InterconnectConfigurable(Configurable):

--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -51,7 +51,7 @@ class _PassThroughFromMux(Generator):
 
 
 def flatten_mux(mux):
-    if mux.height != 1:
+    if mux.height > 1:
         return mux
     return _PassThroughFromMux(mux)
 

--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -11,6 +11,7 @@ from .cyclone import Node, PortNode, Tile, SwitchBoxNode, SwitchBoxIO, \
     SwitchBox, InterconnectCore, RegisterNode, RegisterMuxNode
 import mantle
 from gemstone.common.mux_wrapper import MuxWrapper
+from gemstone.generator.generator import Generator
 import magma
 from typing import Dict, Tuple, List
 from abc import abstractmethod
@@ -34,6 +35,27 @@ def get_mux_sel_name(node: Node):
     return f"{create_name(str(node))}_sel"
 
 
+class _PassThroughFromMux(Generator):
+    def __init__(self, mux):
+        super().__init__()
+        self.width = mux.width
+        self.height = mux.height
+        self.instance_name = mux.instance_name
+        self._name = mux.name()
+        self.add_ports(I=magma.In(magma.Bits[mux.width]),
+                       O=magma.Out(magma.Bits[mux.width]))
+        self.wire(self.ports.I, self.ports.O)
+
+    def name(self):
+        return self._name
+
+
+def _flatten_mux(mux):
+    if mux.height != 1:
+        return mux
+    return _PassThroughFromMux(mux)
+
+
 def create_mux(node: Node):
     conn_in = node.get_conn_in()
     height = len(conn_in)
@@ -46,7 +68,7 @@ def create_mux(node: Node):
     else:
         name = f"WIRE_{node_name}"
     mux = MuxWrapper(height, node.width, name=name)
-    return mux
+    return _flatten_mux(mux)
 
 
 class InterconnectConfigurable(Configurable):

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -122,10 +122,15 @@ class Interconnect(generator.Generator):
                         # using the tile-level port is fine
                         dst_tile = self.tile_circuits[(sb_node.x, sb_node.y)]
                         # wire them up
-                        idx = sb_node.get_conn_in().index(src_node)
                         dst_sb_name = create_name(str(sb_node))
-                        self.wire(tile.ports[src_sb_name],
-                                  dst_tile.ports[dst_sb_name])
+                        if len(sb_node.get_conn_in()) == 1:
+                            # no array
+                            self.wire(tile.ports[src_sb_name],
+                                      dst_tile.ports[dst_sb_name])
+                        else:
+                            idx = sb_node.get_conn_in().index(src_node)
+                            self.wire(tile.ports[src_sb_name][idx],
+                                      dst_tile.ports[dst_sb_name])
 
         # connect these margin tiles, if needed
         self.__connect_margin_tiles()

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -125,7 +125,7 @@ class Interconnect(generator.Generator):
                         idx = sb_node.get_conn_in().index(src_node)
                         dst_sb_name = create_name(str(sb_node))
                         self.wire(tile.ports[src_sb_name],
-                                  dst_tile.ports[dst_sb_name][idx])
+                                  dst_tile.ports[dst_sb_name])
 
         # connect these margin tiles, if needed
         self.__connect_margin_tiles()
@@ -262,11 +262,6 @@ class Interconnect(generator.Generator):
 
                             next_port = \
                                 self.tile_circuits[next_coord].ports[sb_name]
-                            if sb_node.io == SwitchBoxIO.SB_IN:
-                                next_port = next_port[0]
-                            else:
-                                tile_port = tile_port[0]
-
                             self.wire(tile_port, next_port)
 
     def __ground_ports(self):
@@ -282,7 +277,7 @@ class Interconnect(generator.Generator):
                     # no connection to that sb port, ground it
                     sb_name = create_name(str(sb))
                     sb_port = self.tile_circuits[coord].ports[sb_name]
-                    self.wire(ground, sb_port[0])
+                    self.wire(ground, sb_port)
 
     def __cleanup_tiles(self):
         tiles_to_remove = set()


### PR DESCRIPTION
@Kuree I noticed that because we have 1:1 muxes on the inputs of Tile's (and SB's), the interface for the Tile and SB has like `Array[1, Bits[N]]` for inputs and `Bits[N]` for outputs (N = 1, 16). This should definitely be changed, even if internally things are expanded.

I did this the simplest, least invasive way I could think of but not sure it's the best way. Also not sure what downstream ramifications it could have.