### PR TITLE
Condensed register space

### DIFF
--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -776,9 +776,10 @@ class TileCircuit(generator.Generator):
             circuit = self.sbs[src_node.width]
         else:
             raise NotImplementedError(type(dst_node))
-        reg_index = self.__find_reg_index(circuit, dst_node)
+        reg_name = get_mux_sel_name(dst_node)
+        reg_idx, config_data = circuit.get_config_data(reg_name, config_data)
         feature_addr = self.features().index(circuit)
-        return reg_index, feature_addr, config_data
+        return reg_idx, feature_addr, config_data
 
     def __lift_ports(self):
         # lift the internal ports only if we have empty switch boxes
@@ -810,13 +811,6 @@ class TileCircuit(generator.Generator):
                 # if it has connection, then we connect it to the core
                 self.add_port(port_name, magma.Out(magma.Bits[bit_width]))
                 self.wire(self.ports[port_name], self.core.ports[port_name])
-
-    @staticmethod
-    def __find_reg_index(circuit: InterconnectConfigurable, node: Node):
-        config_names = list(circuit.registers.keys())
-        config_names.sort()
-        mux_sel_name = get_mux_sel_name(node)
-        return config_names.index(mux_sel_name)
 
     def name(self):
         if self.core is not None:

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -540,6 +540,22 @@ class Interconnect(generator.Generator):
                 result.append(tile)
         return result
 
+    def get_skip_addr(self):
+        result = set()
+        for y in range(self.y_min, self.y_max + 1):  # y_max is inclusive
+            for x in range(self.x_min, self.x_max + 1): # x_max is inclusive
+                tile = self.tile_circuits[(x, y)]
+                for idx, feat in enumerate(tile.features()):
+                    if hasattr(feat, "skip_compression") and \
+                            feat.skip_compression:
+                        # need to skip all address in this feature space
+                        # compute the number address here
+                        num_addr = 1 << self.config_addr_width
+                        for reg_addr in range(num_addr):
+                            addr = self.get_config_addr(reg_addr, idx, x, y)
+                            result.add(addr)
+        return result
+
     def get_graph(self, bit_width: int):
         return self.__graphs[bit_width]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git://github.com/StanfordAHA/gemstone.git@compact_reg#egg=gemstone
+-e git://github.com/StanfordAHA/gemstone.git#egg=gemstone

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
+-e git://github.com/StanfordAHA/gemstone.git@compact_reg#egg=gemstone

--- a/tests/test_interconnect.py
+++ b/tests/test_interconnect.py
@@ -327,3 +327,12 @@ def test_parallel_meso_wiring(num_cfg: int):
     with tempfile.TemporaryDirectory() as tempdir:
         rtl_path = os.path.join(tempdir, "rtl")
         magma.compile(rtl_path, circuit, output="coreir-verilog")
+
+
+def test_skip_addr():
+    _, _, _, interconnect = create_dummy_cgra(2, 2, False,
+                                              GlobalSignalWiring.ParallelMeso)
+    # set 1, 1 to be ignored addr
+    interconnect.tile_circuits[(1, 1)].core.skip_compression = True
+    skip_addrs = interconnect.get_skip_addr()
+    assert len(skip_addrs) == 256

--- a/tests/test_interconnect.py
+++ b/tests/test_interconnect.py
@@ -1,6 +1,7 @@
 from hwtypes import BitVector
 from gemstone.common.dummy_core_magma import DummyCore
 from gemstone.common.testers import BasicTester
+from gemstone.common.util import compress_config_data
 from canal.checker import check_graph_isomorphic
 from canal.interconnect import *
 import tempfile
@@ -155,6 +156,7 @@ def test_interconnect(num_tracks: int, chip_size: int,
                                                                    next_node)
 
                         config_entry.append(entry)
+                    config_entry = compress_config_data(config_entry)
                     assert src_node is not None and dst_node is not None
                     config_data.append(config_entry)
                     value = fault.random.random_bv(bit_width)
@@ -190,6 +192,7 @@ def test_interconnect(num_tracks: int, chip_size: int,
                                                                    next_node)
 
                         config_entry.append(entry)
+                    config_entry = compress_config_data(config_entry)
                     assert src_node is not None and dst_node is not None
                     config_data.append(config_entry)
                     value = fault.random.random_bv(bit_width)


### PR DESCRIPTION
Better and more condensed register space
----
This PR introduces more condensed register space for garnet, along with gemstone. This is one of the PRs that enables virtualization on CGRA.

## What it does:
1. Instead of allocating a register slot for every configuration register, it tries to pack as many as it can that fits `config_data_width`. 
2.  Allows a core designer to skip compressing the register space. This is useful for SRAM content for lake since it uses a sequencer for config read and write.

## Benefits:
1. Significantly reduce the bitstream size. By my rough calculation it is at least 2x reduction. This is very helpful for hardware virtualization as we can save storage space in the glb.
2. Config register area reduction. It reduces the MEM tile area by 3%. As a whole it is not a lot, but should help Pond to reduce the area overhead.

## Related PR:
https://github.com/StanfordAHA/garnet/pull/656
https://github.com/StanfordAHA/gemstone/pull/41

## Tests:
Since this is a cross-repo change, AHA flow test will not pass on this one. This whole flow tests is tested here:
https://github.com/StanfordAHA/aha/commit/6fad56debecbaeb501bce564c54cbf40d31ed948
which passes the whole flow test here:
https://buildkite.com/stanford-aha/aha-flow/builds/3030#6e774b31-7e6c-49a3-8ee0-94a2c573be0a