### PR TITLE
add simple one tile random route

### DIFF
--- a/canal/pnr_io.py
+++ b/canal/pnr_io.py
@@ -1,5 +1,6 @@
 from canal.interconnect import Interconnect
-from canal.cyclone import SwitchBoxIO, SwitchBoxSide
+from typing import List
+from canal.cyclone import Node
 
 
 def __parse_raw_routing_result(filename):
@@ -76,3 +77,112 @@ def load_placement(filename):
         placement[blk_id] = (x, y)
         id_to_name[blk_id] = blk_name
     return placement, id_to_name
+
+
+def __route(src_node: Node, dst_node: Node, used_nodes):
+    from queue import Queue
+    working_set = Queue()
+    path = {}
+    visited = set()
+    working_set.put(src_node)
+
+    while not working_set.empty():
+        node = working_set.get()
+        if node in visited or node in used_nodes:
+            continue
+        visited.add(node)
+        for n in node:
+            path[n] = node
+            if n == dst_node:
+                # need to return the result
+                result = []
+                t = n
+                while t in path:
+                    result.append(t)
+                    t = path[t]
+                assert result[-1] in src_node
+                result.append(src_node)
+                # reverse the result
+                result = result[::-1]
+                return result
+            else:
+                working_set.put(n)
+    raise RuntimeError(f"Unable to route from {src_node} {dst_node}")
+
+
+def __get_ports(interconnect: Interconnect, bit_width, predicate):
+    interface = interconnect.interface()
+    result = []
+    for port_name in interface:
+        port = interconnect.ports[port_name]
+        port_type = port.base_type()
+        node = interface[port_name]
+        if node.width != bit_width:
+            continue
+        if predicate(port_type):
+            result.append(node)
+    return result
+
+
+def __get_input_ports(interconnect: Interconnect, bit_width: int):
+    return __get_ports(interconnect, bit_width, lambda x: x.is_input())
+
+
+def __get_output_ports(interconnect: Interconnect, bit_width: int):
+    return __get_ports(interconnect, bit_width, lambda x: x.is_output())
+
+
+def route_one_tile(interconnect: Interconnect,
+                   x: int,
+                   y: int,
+                   ports: List[str],
+                   seed: int = 0):
+    import random
+    r = random.Random(seed)
+
+    result = {}
+    tile = interconnect.tile_circuits[(x, y)]
+    port_nodes = {}
+    for tile_g in tile.tiles.values():
+        for p, node in tile_g.ports.items():
+            if p in ports:
+                port_nodes[p] = node
+
+    # check if we've found all port nodes
+    for p in ports:
+        if p not in port_nodes:
+            raise ValueError(f"Unable to find port {p}")
+    used_nodes = set()
+    # sort the keys to be deterministic
+    port_names = list(port_nodes.keys())
+    port_names.sort()
+    input_ports = {}
+    output_ports = {}
+    for bit_width in interconnect.get_bit_widths():
+        input_ports[bit_width] = __get_input_ports(interconnect, bit_width)
+        output_ports[bit_width] = __get_output_ports(interconnect, bit_width)
+
+    # based on if it's input or output
+    used_nodes = set()
+    for port_name in port_names:
+        node = port_nodes[port_name]
+        bit_width = node.width
+        if len(node) == 0:
+            # it's an input
+            # randomly choose an input
+            src_index = r.randrange(len(input_ports[bit_width]))
+            src_node = input_ports[bit_width][src_index]
+            input_ports[bit_width].pop(src_index)
+            path = __route(src_node, node, used_nodes)
+        else:
+            # it's on output
+            # randomly choose an output
+            dst_index = r.randrange(len(output_ports[bit_width]))
+            dst_node = output_ports[bit_width][dst_index]
+            output_ports[bit_width].pop(dst_index)
+            path = __route(node, dst_node, used_nodes)
+        for n in path:
+            used_nodes.add(n)
+        result[f"e{len(result)}"] = [path]
+
+    return result


### PR DESCRIPTION
This allows simple random route for a single tile. It should support any arbitrary size of array with the following limitations:
- does not work with more than 1 tile placement
- does not optimize the routing result since the src/dst is chosen at random.