### PR TITLE
Double buffer for configuration registers

### DIFF
--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -111,6 +111,9 @@ class CB(InterconnectConfigurable):
             self.ports.pop("clk")
             self.ports.pop("reset")
             self.ports.pop("read_config_data")
+            if self.double_buffer:
+                self.ports.pop("use_db")
+                self.ports.pop("config_db")
 
         self._setup_config()
 

--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -77,12 +77,14 @@ class InterconnectConfigurable(Configurable):
 
 class CB(InterconnectConfigurable):
     def __init__(self, node: PortNode,
-                 config_addr_width: int, config_data_width: int):
+                 config_addr_width: int, config_data_width: int,
+                 double_buffer: bool = False):
         if not isinstance(node, PortNode):
             raise ValueError(node, PortNode.__name__)
         self.node: PortNode = node
 
-        super().__init__(config_addr_width, config_data_width)
+        super().__init__(config_addr_width, config_data_width,
+                         double_buffer=double_buffer)
 
         self.mux = create_mux(self.node)
 
@@ -121,7 +123,8 @@ class CB(InterconnectConfigurable):
 class SB(InterconnectConfigurable):
     def __init__(self, switchbox: SwitchBox, config_addr_width: int,
                  config_data_width: int, core_name: str = "",
-                 stall_signal_width: int = 4):
+                 stall_signal_width: int = 4,
+                 double_buffer: bool = False):
         self.switchbox = switchbox
         self.__core_name = core_name
         self.stall_signal_width = stall_signal_width
@@ -132,7 +135,8 @@ class SB(InterconnectConfigurable):
 
         self.mux_name_to_node: Dict[str:, Node] = {}
 
-        super().__init__(config_addr_width, config_data_width)
+        super().__init__(config_addr_width, config_data_width,
+                         double_buffer=double_buffer)
 
         # turn off hashing because we control the hash by ourselves
         self.set_skip_hash(True)
@@ -306,7 +310,7 @@ class SB(InterconnectConfigurable):
 
     def name(self):
         return f"SB_ID{self.switchbox.id}_{self.switchbox.num_track}TRACKS_" \
-            f"B{self.switchbox.width}_{self.__core_name}"
+               f"B{self.switchbox.width}_{self.__core_name}"
 
     def __connect_sbs(self):
         # the principle is that it only connects to the nodes within
@@ -372,11 +376,13 @@ class TileCircuit(generator.Generator):
     We don't deal with stall signal here since it's not interconnect's job
     to handle that signal
     """
+
     def __init__(self, tiles: Dict[int, Tile],
                  config_addr_width: int, config_data_width: int,
                  tile_id_width: int = 16,
                  full_config_addr_width: int = 32,
-                 stall_signal_width: int = 4):
+                 stall_signal_width: int = 4,
+                 double_buffer: bool = False):
         super().__init__()
 
         # turn off hashing because we controls that hashing here
@@ -386,6 +392,8 @@ class TileCircuit(generator.Generator):
         self.config_addr_width = config_addr_width
         self.config_data_width = config_data_width
         self.tile_id_width = tile_id_width
+
+        self.double_buffer = double_buffer
 
         # compute config addr sizes
         # (16, 24)
@@ -448,7 +456,8 @@ class TileCircuit(generator.Generator):
                         continue
                     # create a CB
                     port_ref = tile.get_port_ref(port_node.name)
-                    cb = CB(port_node, config_addr_width, config_data_width)
+                    cb = CB(port_node, config_addr_width, config_data_width,
+                            double_buffer=self.double_buffer)
                     self.wire(cb.ports.O, port_ref)
                     self.cbs[port_name] = cb
                 else:
@@ -459,7 +468,8 @@ class TileCircuit(generator.Generator):
             # switch box time
             core_name = self.core.name() if self.core is not None else ""
             sb = SB(tile.switchbox, config_addr_width, config_data_width,
-                    core_name, stall_signal_width=stall_signal_width)
+                    core_name, stall_signal_width=stall_signal_width,
+                    double_buffer=self.double_buffer)
             self.sbs[sb.switchbox.width] = sb
 
         # lift all the sb ports up
@@ -680,6 +690,12 @@ class TileCircuit(generator.Generator):
             clk=magma.In(magma.Clock),
             read_config_data=magma.Out(magma.Bits[self.config_data_width])
         )
+        # double buffer ports
+        if self.double_buffer:
+            self.add_ports(
+                config_db=magma.In(magma.Bit),
+                use_db=magma.In(magma.Bit)
+            )
 
         features = self.features()
         num_features = len(features)
@@ -698,6 +714,10 @@ class TileCircuit(generator.Generator):
             self.wire(self.ports.config.config_data,
                       feature.ports.config.config_data)
             self.wire(self.ports.config.read, feature.ports.config.read)
+
+            if self.double_buffer and "config_db" in feature.ports:
+                self.wire(self.ports.config_db, feature.ports.config_db)
+                self.wire(self.ports.use_db, feature.ports.use_db)
 
         # Connect S input to config_addr.feature.
         self.wire(self.ports.config.config_addr[self.feature_addr_slice],
@@ -762,9 +782,9 @@ class TileCircuit(generator.Generator):
     def get_route_bitstream_config(self, src_node: Node, dst_node: Node):
         assert src_node.width == dst_node.width
         tile = self.tiles[src_node.width]
-        assert dst_node.x == tile.x and dst_node.y == tile.y,\
+        assert dst_node.x == tile.x and dst_node.y == tile.y, \
             f"{dst_node} is not in {tile}"
-        assert dst_node in src_node,\
+        assert dst_node in src_node, \
             f"{dst_node} is not connected to {src_node}"
 
         config_data = dst_node.get_conn_in().index(src_node)

--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,11 @@
 import pytest
+import magma
 from magma import clear_cachedFunctions
-import magma.backend.coreir_ as coreir_
 from gemstone.generator import clear_generator_cache
 
 
 @pytest.fixture(autouse=True)
 def magma_test():
     clear_cachedFunctions()
-    coreir_.CoreIRContextSingleton().reset_instance()
+    magma.frontend.coreir_.ResetCoreIR()
     clear_generator_cache()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
+-e git://github.com/StanfordAHA/gemstone.git@db#egg=gemstone

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git://github.com/StanfordAHA/gemstone.git@db#egg=gemstone
+-e git://github.com/StanfordAHA/gemstone.git#egg=gemstone

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -669,4 +669,4 @@ def test_double_buffer():
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
                                directory=tempdir,
-                               flags=["-Wno-fatal", "--trace"])
+                               flags=["-Wno-fatal"])

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -609,16 +609,22 @@ def test_double_buffer():
     out_port_node = tile_circuit.tiles[bit_width].ports[output_port_name]
     in_port_node = tile_circuit.tiles[bit_width].ports[input_port_name]
 
-    input_1 = sb_circuit.switchbox.get_sb(SwitchBoxSide.NORTH, 0, SwitchBoxIO.SB_IN)
+    input_1 = sb_circuit.switchbox.get_sb(SwitchBoxSide.NORTH, 0,
+                                          SwitchBoxIO.SB_IN)
     input_1_name = create_name(str(input_1))
-    input_2 = sb_circuit.switchbox.get_sb(SwitchBoxSide.EAST, 1, SwitchBoxIO.SB_IN)
+    input_2 = sb_circuit.switchbox.get_sb(SwitchBoxSide.EAST, 1,
+                                          SwitchBoxIO.SB_IN)
     input_2_name = create_name(str(input_2))
-    output_sb = sb_circuit.switchbox.get_sb(SwitchBoxSide.SOUTH, 2, SwitchBoxIO.SB_OUT)
+    output_sb = sb_circuit.switchbox.get_sb(SwitchBoxSide.SOUTH, 2,
+                                            SwitchBoxIO.SB_OUT)
     output_name = create_name(str(output_sb))
 
-    input_1_bitstream = tile_circuit.get_route_bitstream_config(input_1, in_port_node)
-    input_2_bitstream = tile_circuit.get_route_bitstream_config(input_2, in_port_node)
-    output_bitstream = tile_circuit.get_route_bitstream_config(out_port_node, output_sb)
+    input_1_bitstream = tile_circuit.get_route_bitstream_config(input_1,
+                                                                in_port_node)
+    input_2_bitstream = tile_circuit.get_route_bitstream_config(input_2,
+                                                                in_port_node)
+    output_bitstream = tile_circuit.get_route_bitstream_config(out_port_node,
+                                                               output_sb)
     # notice that both of them will be configured using the double buffer scheme
 
     def get_config_data(config_data, reg_data):

--- a/tests/test_interconnect.py
+++ b/tests/test_interconnect.py
@@ -254,7 +254,8 @@ def test_interconnect(num_tracks: int, chip_size: int,
     #     check_graph_isomorphic(ics, rtl_path)
 
 
-def test_1x1():
+@pytest.mark.parametrize("double_buffer", [True, False])
+def test_1x1(double_buffer):
     ics = {}
     in_conn = []
     out_conn = []
@@ -275,7 +276,7 @@ def test_1x1():
                                          SwitchBoxType.Disjoint)
         ics[bit_width] = ic
     interconnect = Interconnect(ics, addr_width, data_width, 16,
-                                lift_ports=True)
+                                lift_ports=True, double_buffer=double_buffer)
     interconnect.finalize()
     apply_global_fanout_wiring(interconnect)
     circuit = interconnect.circuit()


### PR DESCRIPTION
Add shadow config register implementation. This will be part of dynamic partial configuration (DPR) research effort.

Notice that this change is backward-compatible, meaning the downstream tools will continue to work even if not using double buffer.

Depends on https://github.com/StanfordAHA/gemstone/pull/47