### PR TITLE
Fixed meso wiring bug when first tile in column has config port

### DIFF
--- a/canal/global_signal.py
+++ b/canal/global_signal.py
@@ -107,9 +107,8 @@ def apply_global_meso_wiring(interconnect: Interconnect, io_sides: IOSide = IOSi
                 pre_port = pass_signal_through(tile, signal)
                 pre_ports.append(pre_port)
             # second pass to wire them up
-            for i in range(start, end - 1):
+            for pre_port, i in zip(pre_ports, range(start, end - 1)):
                 next_tile = column[i + 1]
-                pre_port = pre_ports[i]
                 interconnect.wire(pre_port,
                                   next_tile.ports[signal])
 


### PR DESCRIPTION
This wiring pass only works when the first tile in the column does not have a "config" port. With the IO tile that has the configurable pipeline register, the global signals were not being passed down from one tile to the next.