### PR TITLE
Enable the ability to add an IO tile with registers with no configuration

### DIFF
--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -914,28 +914,28 @@ class TileCircuit(GemstoneGenerator):
     def __add_stall(self):
         # automatically add stall signal and connect it to the features if the
         # feature supports it
-        stall_ports = []
+        stall_ports = set()
         for feature in self.features():
             if "stall" in feature.ports.keys():
-                stall_ports.append(feature.ports.stall)
+                stall_ports.add(feature.ports.stall)
         # some core may not expose the port as features, such as mem cores
         if self.core is not None and "stall" in self.core.ports and \
                 self.core.ports.stall not in stall_ports:
-            stall_ports.append(self.core.ports.stall)
+            stall_ports.add(self.core.ports.stall)
         for stall_port in stall_ports:
             self.wire(self.ports.stall, stall_port)
 
     def __add_reset(self):
         # automatically add reset signal and connect it to the features if the
         # feature supports it
-        reset_ports = []
+        reset_ports = set()
         for feature in self.features():
             if "reset" in feature.ports.keys():
-                reset_ports.append(feature.ports.reset)
+                reset_ports.add(feature.ports.reset)
         # some core may not expose the port as features, such as mem cores
         if self.core is not None and "reset" in self.core.ports and \
                 self.core.ports.reset not in reset_ports:
-            reset_ports.append(self.core.ports.reset)
+            reset_ports.add(self.core.ports.reset)
 
         for reset_port in reset_ports:
             self.wire(self.ports.reset, reset_port)
@@ -943,14 +943,14 @@ class TileCircuit(GemstoneGenerator):
     def __add_clk(self):
         # automatically add clk signal and connect it to the features if the
         # feature supports it
-        clk_ports = []
+        clk_ports = set()
         for feature in self.features():
             if "clk" in feature.ports.keys():
-                clk_ports.append(feature.ports.clk)
+                clk_ports.add(feature.ports.clk)
         # some core may not expose the port as features, such as mem cores
         if self.core is not None and "clk" in self.core.ports and \
                 self.core.ports.clk not in clk_ports:
-            clk_ports.append(self.core.ports.clk)
+            clk_ports.add(self.core.ports.clk)
 
         for clk_port in clk_ports:
             self.wire(self.ports.clk, clk_port)

--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -961,12 +961,6 @@ class TileCircuit(GemstoneGenerator):
         for feature in self.features():
             if "config" in feature.ports:
                 return True
-            # else:
-                # if the feature doesn't have config port, it shouldn't have
-                # reset either, although the other way around may be true
-                # that is, a feature may have some internal states that need
-                # to reset, but not necessarily has config port
-                # assert "reset" not in feature.ports
         return False
 
     def wire_internal(self, port1: str, port2: str):

--- a/canal/global_signal.py
+++ b/canal/global_signal.py
@@ -85,7 +85,6 @@ def apply_global_meso_wiring(interconnect: Interconnect, io_sides: IOSide = IOSi
     for x in range(x_min, x_max + 1):
         column = interconnect.get_column(x)
         # skip the margin
-        column = [entry for entry in column if "config" in entry.ports]
         if len(column) == 0:
             continue
         # wire global inputs to first tile in column
@@ -117,6 +116,7 @@ def apply_global_meso_wiring(interconnect: Interconnect, io_sides: IOSide = IOSi
         # along with OR gate to reduce input read_data with
         # that tile's read_data
         # ports_in keep track of new ports created by or_reduction
+        column = [entry for entry in column if "config" in entry.ports]
         ports_in = []
         for tile in column:
             port_in = or_reduction(tile, "read_data_mux", "read_config_data",


### PR DESCRIPTION
Alex asked for an IO tile with registers that didn't have any configuration, so these changes are necessary to get that working.