### PR TITLE
don't create flush port on margin tile

### DIFF
--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -272,6 +272,8 @@ class Interconnect(generator.Generator):
                 if tile.switchbox.num_track > 0 or tile.core is None:
                     continue
                 for port_name, port_node in tile.ports.items():
+                    if port_name == "flush":
+                        continue
                     tile_port = self.tile_circuits[coord].ports[port_name]
                     # FIXME: this is a hack
                     valid_connected = False


### PR DESCRIPTION
Maybe this isn't the way you want it done - but flush should not be created as an IO for the whole interconnect (whereas the other io2glb/glb2io pins are)