### PR TITLE
Fix split fifo algo top allow for multiple split fifos per route

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ place and route directly. To install `archipelago`, you can use
 pip install archipelago
 ```
 It will use pre-built Python native wheels to speed up place and route.
+
+-------
+A new kratos-based of canal is [here](https://github.com/Kuree/kcanal).

--- a/canal/cyclone.py
+++ b/canal/cyclone.py
@@ -702,11 +702,15 @@ class InterconnectGraph:
             self.set_core_connection(x, y, port_name, connections)
 
     def set_inter_core_connection(self, from_name: str, to_name: str):
+        connection_added = False
         for tile in self.__tiles.values():
             from_node: PortNode = tile.get_port(from_name)
             to_node: PortNode = tile.get_port(to_name)
             if from_node is not None and to_node is not None:
                 from_node.add_edge(to_node)
+                connection_added = True
+        assert connection_added, \
+        f"Couldn't make inter-core connection betweeen {from_name} and {to_name}"
 
     def set_core(self, x: int, y: int, core: InterconnectCore):
         tile = self.get_tile(x, y)

--- a/canal/cyclone.py
+++ b/canal/cyclone.py
@@ -701,16 +701,19 @@ class InterconnectGraph:
                                                         io))
             self.set_core_connection(x, y, port_name, connections)
 
-    def set_inter_core_connection(self, from_name: str, to_name: str):
-        connection_added = False
-        for tile in self.__tiles.values():
-            from_node: PortNode = tile.get_port(from_name)
-            to_node: PortNode = tile.get_port(to_name)
-            if from_node is not None and to_node is not None:
-                from_node.add_edge(to_node)
-                connection_added = True
-        assert connection_added, \
-        f"Couldn't make inter-core connection betweeen {from_name} and {to_name}"
+    def set_inter_core_connection(self, inter_core_connection):
+        self.inter_core_connection = inter_core_connection
+        for from_name, to_names in inter_core_connection.items():
+            for to_name in to_names: 
+                connection_added = False
+                for tile in self.__tiles.values():
+                    from_node: PortNode = tile.get_port(from_name)
+                    to_node: PortNode = tile.get_port(to_name)
+                    if from_node is not None and to_node is not None:
+                        from_node.add_edge(to_node)
+                        connection_added = True
+                assert connection_added, \
+                f"Couldn't make inter-core connection betweeen {from_name} and {to_name}"
 
     def set_core(self, x: int, y: int, core: InterconnectCore):
         tile = self.get_tile(x, y)

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -272,6 +272,8 @@ class Interconnect(generator.Generator):
                 if tile.switchbox.num_track > 0 or tile.core is None:
                     continue
                 for port_name, port_node in tile.ports.items():
+                    if port_name == "flush":
+                        continue
                     tile_port = self.tile_circuits[coord].ports[port_name]
                     # FIXME: this is a hack
                     valid_connected = False

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -522,12 +522,14 @@ class Interconnect(generator.Generator):
                         idx += 1
                     if len(reg_nodes) != 0:
                         assert len(reg_nodes) != 1, "Cannot have standalone FIFO reg in the segment"
-                        first_node = reg_nodes[0]
-                        last_node = reg_nodes[-1]
-                        config = self.__set_fifo_mode(first_node, True, False)
-                        result += config
-                        config = self.__set_fifo_mode(last_node, False, True)
-                        result += config
+                        assert len(reg_nodes) % 2 == 0, "Must have even number of FIFO regs"
+                        for idx in range(0, len(reg_nodes), 2):
+                            first_node = reg_nodes[idx]
+                            last_node = reg_nodes[idx + 1]
+                            config = self.__set_fifo_mode(first_node, True, False)
+                            result += config
+                            config = self.__set_fifo_mode(last_node, False, True)
+                            result += config
 
         return result
 

--- a/canal/logic.py
+++ b/canal/logic.py
@@ -281,12 +281,12 @@ class SplitFifo(Generator):
         fifo_en = self.input("fifo_en", 1)
 
         # need to add clock enables
-        self.clock_en("clk_en")
+        clk_en = self.clock_en("clk_en")
 
         self.wire(ready_in, ready1.and_(~start_fifo))
-        self.wire(ready0, kratos.ternary(fifo_en, empty.or_(ready_in), 1))
+        self.wire(ready0, kratos.ternary(fifo_en, empty.or_(ready_in), clk_en))
         self.wire(valid_in, valid0.and_(~end_fifo))
-        self.wire(valid1, kratos.ternary(fifo_en, (~empty).or_(valid_in), 1))
+        self.wire(valid1, kratos.ternary(fifo_en, (~empty).or_(valid_in), clk_en))
 
         self.wire(data_out, kratos.ternary(empty.and_(fifo_en), data_in, value))
 
@@ -294,7 +294,7 @@ class SplitFifo(Generator):
         def value_logic():
             if rst:
                 value = 0
-            else:
+            elif clk_en:
                 if (~fifo_en).or_(valid0.and_(ready0).and_(~(empty.and_(ready1).and_(valid1)))):
                     value = data_in
 
@@ -302,7 +302,7 @@ class SplitFifo(Generator):
         def empty_logic():
             if rst:
                 empty_n = 0
-            else:
+            elif clk_en:
                 if fifo_en:
                     if valid1.and_(ready1):
                         if ~(valid0.and_(ready0)):

--- a/canal/util.py
+++ b/canal/util.py
@@ -146,9 +146,7 @@ def create_uniform_interconnect(width: int,
         interconnect.set_core_connection_all(port_name, conns)
 
     if inter_core_connection is not None:
-        for from_name, to_names in inter_core_connection.items():
-            for to_name in to_names:
-                interconnect.set_inter_core_connection(from_name, to_name)
+        interconnect.set_inter_core_connection(inter_core_connection)
 
     # set the actual interconnections
     # sort the tracks by length


### PR DESCRIPTION
Previously only only split fifo was allowed per route, this fix addresses this