### PR TITLE
Hetero cgra lopsided layout 

### DIFF
--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -275,7 +275,6 @@ class Interconnect(generator.Generator):
         else:
             return tile.switchbox.num_track > 0
 
-    # FIXME: This is a hack. Why are io2f and f2io tiles ports in the first place? They shouldn't be... 
     def dont_lift_port(self, tile, port_name):
         # dont lift f2io and io2f ports to interconnect level since these connect to the SB within the I/O tile 
         return self.give_north_io_sbs and (tile.y == 0 and ("f2io" in port_name or "io2f" in port_name))

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -715,8 +715,6 @@ class Interconnect(generator.Generator):
         elif node_str[0] == "REG":
             reg_name, track, x, y, bit_width = node_str[1:]
             graph = self.get_graph(bit_width)
-            if reg_name not in graph.get_tile(x, y).switchbox.registers:
-                breakpoint()
             return graph.get_tile(x, y).switchbox.registers[reg_name]
         elif node_str[0] == "RMUX":
             rmux_name, x, y, bit_width = node_str[1:]

--- a/canal/util.py
+++ b/canal/util.py
@@ -37,9 +37,7 @@ def compute_num_tracks(x_offset: int, y_offset: int,
 
 
 def get_array_size(width, height, io_sides):
-    # MO Hack 
-    x_min = 0
-    #x_min = 1 if IOSide.West in io_sides else 0
+    x_min = 1 if IOSide.West in io_sides else 0
     x_max = width - 2 if IOSide.East in io_sides else width - 1
     y_min = 1 if IOSide.North in io_sides else 0
     y_max = height - 2 if IOSide.South in io_sides else height - 1
@@ -207,8 +205,18 @@ def create_uniform_interconnect(width: int,
     current_track = 0
     for track_len in track_lens:
         for _ in range(track_info[track_len]):
+
+            # This function connects neighboring switchboxes to each other (North, south east, west)
+            # MO: HACK: try doing in two passes 
             interconnect.connect_switchbox(interconnect_x_min, interconnect_y_min, interconnect_x_max,
                                            interconnect_y_max,
+                                           track_len,
+                                           current_track,
+                                           InterconnectPolicy.Ignore)
+
+            # For unconnected I/O tiles 
+            interconnect.connect_switchbox(x_min, interconnect_y_min, interconnect_x_max,
+                                           interconnect_y_min,
                                            track_len,
                                            current_track,
                                            InterconnectPolicy.Ignore)


### PR DESCRIPTION
Changes to enable removing columns from the CGRA while keeping the number of GLB tiles the same. This opens up space in the tile array to insert another component (e.g., Matrix unit)