### PR TITLE
Zircon dense rv changes 2

### DIFF
--- a/canal/checker.py
+++ b/canal/checker.py
@@ -1,5 +1,5 @@
 import coreir
-from .cyclone import InterconnectGraph, SwitchBoxSide, SwitchBoxIO, Node,\
+from .cyclone import InterconnectGraph, SwitchBoxSide, SwitchBoxIO, Node, \
     RegisterMuxNode, Tile, SwitchBoxNode, RegisterNode, SwitchBox, PortNode
 import os
 from typing import Dict, List, Tuple, Set, Union

--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -19,9 +19,10 @@ from gemstone.generator.generator import Generator as GemstoneGenerator
 from gemstone.generator.from_magma import FromMagma
 from mantle import DefineRegister
 from gemstone.generator.const import Const
-from .logic import ExclusiveNodeFanout, InclusiveNodeFanout, ReadyValidLoopBack, \
-    FifoRegWrapper
+from .logic import ExclusiveNodeFanout, InclusiveNodeFanout, \
+    ReadyValidLoopBack, FifoRegWrapper
 import os
+
 
 def get_mux_sel_name(node: Node):
     return f"{create_name(str(node))}_sel"
@@ -90,6 +91,7 @@ def _safe_wire(self, port1, port2):
             or port2.base_type() is magma.BitOut and port1.base_type() is magma.Out(magma.Bits[1]):
         return self.wire(port1[0], port2)
     return self.wire(port1, port2)
+
 
 class InterconnectConfigurable(Configurable):
     def safe_wire(self, port1, port2):
@@ -376,7 +378,6 @@ class SB(InterconnectConfigurable):
             self.wire(reg.ports.CE, self.convert(and_gate.ports.O[0],
                                                  magma.enable))
 
-
     def _wire_flush(self):
         if len(self.regs) == 0:
             return
@@ -488,7 +489,7 @@ class SB(InterconnectConfigurable):
                 self.wire(fifo_en.ports.O[0], reg.ports.fifo_en)
 
                 # set start and end if using splitFIFOs
-                if not(self.use_non_split_fifos):
+                if not self.use_non_split_fifos:
                     start_name = str(node) + "_start"
                     self.add_config(start_name, 1)
                     start = self.registers[start_name]
@@ -511,7 +512,6 @@ class SB(InterconnectConfigurable):
                     self.wire(bogus_init.ports.O, reg.ports.bogus_init)
                 else:
                     self.wire(bogus_init.ports.O[0], reg.ports.bogus_init)
-
 
     def __handle_rmux_fanin(self, sb: SwitchBoxNode, rmux: RegisterMuxNode,
                             reg: RegisterNode):
@@ -1008,8 +1008,7 @@ class TileCircuit(GemstoneGenerator):
         # add ports
         self.add_ports(stall=magma.In(magma.Bits[stall_signal_width]),
                        reset=magma.In(magma.AsyncReset),
-                       clk=magma.In(magma.Clock),
-        )
+                       clk=magma.In(magma.Clock))
 
         # lift ports if there is empty sb
         self.__lift_ports()
@@ -1113,7 +1112,6 @@ class TileCircuit(GemstoneGenerator):
 
         for clk_port in clk_ports:
             self.wire(self.ports.clk, clk_port)
-
 
     def __wire_flush_to_sbs(self):
         for _, switchbox in self.sbs.items():
@@ -1310,7 +1308,8 @@ class TileCircuit(GemstoneGenerator):
             return configs
         return base_config
 
-    def configure_fifo(self, node: RegisterNode, start: bool, end: bool, use_non_split_fifos: bool = False, bogus_init: bool = False, bogus_init_num: int = 0):
+    def configure_fifo(self, node: RegisterNode, start: bool, end: bool, use_non_split_fifos: bool = False,
+                       bogus_init: bool = False, bogus_init_num: int = 0):
         configs = []
         # we only turn this on if it's a path from register to mux with ready-valid
         circuit = self.sbs[node.width]
@@ -1320,7 +1319,7 @@ class TileCircuit(GemstoneGenerator):
         self.__add_additional_config(bogus_init_name, bogus_init_num, circuit, configs)
 
         # Only do start and end config for split FIFOs
-        if not(use_non_split_fifos):
+        if not use_non_split_fifos:
             start_name = str(node) + "_start"
             end_name = str(node) + "_end"
             start = int(start)

--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -491,6 +491,14 @@ class SB(InterconnectConfigurable):
                 end = self.registers[end_name]
                 self.wire(end.ports.O[0], reg.ports.end_fifo)
 
+                # MO: Flush signal HACK
+                # Set bogus mode 
+                bogus_init_name = str(node) + "_bogus_init"
+                self.add_config(bogus_init_name, 1)
+                bogus_init = self.registers[bogus_init_name]
+                self.wire(bogus_init.ports.O[0], reg.ports.bogus_init)
+
+
     def __handle_rmux_fanin(self, sb: SwitchBoxNode, rmux: RegisterMuxNode,
                             reg: RegisterNode):
         # exclusive because the destination mux can only select one

--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -1256,7 +1256,7 @@ class TileCircuit(GemstoneGenerator):
             return configs
         return base_config
 
-    def configure_fifo(self, node: RegisterNode, start: bool, end: bool):
+    def configure_fifo(self, node: RegisterNode, start: bool, end: bool, bogus_init: bool = False):
         configs = []
         # we only turn this on if it's a path from register to mux with ready-valid
         circuit = self.sbs[node.width]
@@ -1264,10 +1264,13 @@ class TileCircuit(GemstoneGenerator):
         self.__add_additional_config(reg_name, 1, circuit, configs)
         start_name = str(node) + "_start"
         end_name = str(node) + "_end"
+        bogus_init_name = str(node) + "_bogus_init"
         start = int(start)
         end = int(end)
+        bogus_init = int(bogus_init)
         self.__add_additional_config(start_name, start, circuit, configs)
         self.__add_additional_config(end_name, end, circuit, configs)
+        self.__add_additional_config(bogus_init_name, bogus_init, circuit, configs)
         return configs
 
     def __lift_ports(self):

--- a/canal/circuit.py
+++ b/canal/circuit.py
@@ -270,8 +270,6 @@ class SB(InterconnectConfigurable):
         self.instance_name = self.name()
 
         # ready valid interface
-
-        # MO: Flush signal HACK
         self._wire_flush()
         self.__wire_reg_reset()
         self.__connect_nodes_fanin()
@@ -499,7 +497,6 @@ class SB(InterconnectConfigurable):
                     end = self.registers[end_name]
                     self.wire(end.ports.O[0], reg.ports.end_fifo)
 
-                # MO: Flush signal HACK
                 # Set bogus mode
                 bogus_init_name = str(node) + "_bogus_init"
                 if self.use_non_split_fifos:

--- a/canal/cyclone.py
+++ b/canal/cyclone.py
@@ -236,7 +236,7 @@ class SwitchBox:
         self.isTall = isTall
 
         self.num_track = num_track
-        if not(isTall):
+        if not isTall:
             assert num_horizontal_track == 0, "ERROR: Only Tall switchboxes can have num_horziontal_track passed as an argument"
         self.num_horizontal_track = num_horizontal_track if isTall else num_track
 
@@ -261,36 +261,36 @@ class SwitchBox:
                         io_list.append(None)
                     side_list.append(io_list)
                 self.__sbs[side.value] = side_list
-        
+
             # construct the internal connections
             for side in SwitchBoxSide:
                 for io in SwitchBoxIO:
                     for track in range(self.num_track):
                         node = SwitchBoxNode(self.x, self.y, track, width,
-                                            side, io)
+                                             side, io)
                         self.__sbs[side.value][io.value][track] = node
-            
+
             # Extra horizontal tracks
             for io in SwitchBoxIO:
                 for track in range(self.num_track, self.num_horizontal_track):
                     east_node = SwitchBoxNode(self.x, self.y, track, width,
-                                            SwitchBoxSide.EAST, io)
+                                              SwitchBoxSide.EAST, io)
                     west_node = SwitchBoxNode(self.x, self.y, track, width,
-                                            SwitchBoxSide.WEST, io)
+                                              SwitchBoxSide.WEST, io)
                     self.__sbs[SwitchBoxSide.EAST.value][io.value][track] = east_node
                     self.__sbs[SwitchBoxSide.WEST.value][io.value][track] = west_node
 
         else:
             self.__sbs: List[List[List[SwitchBoxNode]]] = \
                 [[[None for _ in range(self.num_track)]
-                for _ in SwitchBoxIO] for _ in SwitchBoxSide]
+                  for _ in SwitchBoxIO] for _ in SwitchBoxSide]
 
             # construct the internal connections
             for side in SwitchBoxSide:
                 for io in SwitchBoxIO:
                     for track in range(self.num_track):
                         node = SwitchBoxNode(self.x, self.y, track, width,
-                                            side, io)
+                                             side, io)
                         self.__sbs[side.value][io.value][track] = node
 
         # assign internal wiring
@@ -336,7 +336,7 @@ class SwitchBox:
             raise ValueError(item[-1])
         side, track, io = item
         return self.__sbs[side.value][io.value][track]
-    
+
     def get_all_sbs(self) -> List[SwitchBoxNode]:
         result = []
         for side in SwitchBoxSide:
@@ -446,6 +446,7 @@ class SwitchBox:
 
         return switchbox
 
+
 # helper class
 class DisjointSwitchBox(SwitchBox):
     def __init__(self, x: int, y: int, num_track: int, width: int):
@@ -457,6 +458,7 @@ class WiltonSwitchBox(SwitchBox):
     def __init__(self, x: int, y: int, num_track: int, width: int):
         internal_wires = SwitchBoxHelper.get_wilton_sb_wires(num_track)
         super().__init__(x, y, num_track, width, internal_wires)
+
 
 class TallWiltonSwitchBox(SwitchBox):
     def __init__(self, x: int, y: int, num_track: int, num_horizontal_track: int, width: int):
@@ -474,6 +476,7 @@ class ImranSwitchBox(SwitchBox):
             internal_wires = SwitchBoxHelper.get_imran_even_sb_wires(num_track)
         super().__init__(x, y, num_track, width, internal_wires)
 
+
 class TallImranSwitchBox(SwitchBox):
     def __init__(self, x: int, y: int, num_track: int, num_horizontal_track: int, width: int):
         if mod(num_track, 2) == 1:
@@ -483,7 +486,6 @@ class TallImranSwitchBox(SwitchBox):
             # even number of tracks
             internal_wires = SwitchBoxHelper.get_tall_imran_even_sb_wires(num_track, num_horizontal_track)
         super().__init__(x, y, num_track, width, internal_wires, num_horizontal_track, isTall=True)
-
 
 
 class CoreConnectionType(enum.Flag):
@@ -508,13 +510,14 @@ class Tile:
         # create a copy of switch box because the switchbox nodes have to be
         # created
         if isTallTile:
-            self.switchbox: SwitchBox = SwitchBox(x, y, switchbox.num_track, 
-                                                switchbox.width,
-                                                switchbox.internal_wires, num_horizontal_track=switchbox.num_horizontal_track, isTall=True)
+            self.switchbox: SwitchBox = SwitchBox(x, y, switchbox.num_track,
+                                                  switchbox.width,
+                                                  switchbox.internal_wires, num_horizontal_track=switchbox.num_horizontal_track,
+                                                  isTall=True)
         else:
-            self.switchbox: SwitchBox = SwitchBox(x, y, switchbox.num_track, 
-                                                switchbox.width,
-                                                switchbox.internal_wires)
+            self.switchbox: SwitchBox = SwitchBox(x, y, switchbox.num_track,
+                                                  switchbox.width,
+                                                  switchbox.internal_wires)
 
         self.ports: Dict[str, PortNode] = {}
 
@@ -565,7 +568,7 @@ class Tile:
                     self.__port_core[port_name].append(core)
 
         if connection_type & CoreConnectionType.SB == CoreConnectionType.SB:
-            
+
             outputs = core.outputs()[:]
             outputs.sort(key=lambda x: x[1])
             for width, port_name in outputs:
@@ -732,7 +735,7 @@ class InterconnectGraph:
             return None
         try:
             result = self.__tile_grid[y][x]
-        # MO: HACK to allow South MU I/O placement to work with blank spaces at the edges 
+        # MO: HACK to allow South MU I/O placement to work with blank spaces at the edges
         except IndexError:
             return None
         return result
@@ -773,7 +776,7 @@ class InterconnectGraph:
             num_track = switch.num_track
             connections: List[SBConnectionType] = []
             for side, io in connection_type:
-                num_tracks_to_loop_over = num_track 
+                num_tracks_to_loop_over = num_track
                 if includeTallConnections:
                     if side == SwitchBoxSide.EAST or side == SwitchBoxSide.WEST:
                         num_tracks_to_loop_over = switch.num_horizontal_track
@@ -785,7 +788,7 @@ class InterconnectGraph:
     def set_inter_core_connection(self, inter_core_connection):
         self.inter_core_connection = inter_core_connection
         for from_name, to_names in inter_core_connection.items():
-            for to_name in to_names: 
+            for to_name in to_names:
                 connection_added = False
                 for tile in self.__tiles.values():
                     from_node: PortNode = tile.get_port(from_name)
@@ -793,8 +796,7 @@ class InterconnectGraph:
                     if from_node is not None and to_node is not None:
                         from_node.add_edge(to_node)
                         connection_added = True
-                assert connection_added, \
-                f"Couldn't make inter-core connection betweeen {from_name} and {to_name}"
+                assert connection_added, f"Couldn't make inter-core connection betweeen {from_name} and {to_name}"
 
     def set_core(self, x: int, y: int, core: InterconnectCore):
         tile = self.get_tile(x, y)
@@ -964,7 +966,7 @@ class InterconnectGraph:
                 self.__add_sb_connection(tile_to, tile_from, track,
                                          SwitchBoxSide.WEST)
 
-        if not(isTallConnection):
+        if not isTallConnection:
             # top to bottom this is very similar to the previous one (left to
             # right)
             for x in range(x0, x1 + 1):
@@ -995,10 +997,10 @@ class InterconnectGraph:
                     # add to connection list
                     # forward
                     self.__add_sb_connection(tile_from, tile_to, track,
-                                            SwitchBoxSide.SOUTH)
+                                             SwitchBoxSide.SOUTH)
                     # backward
                     self.__add_sb_connection(tile_to, tile_from, track,
-                                            SwitchBoxSide.NORTH)
+                                             SwitchBoxSide.NORTH)
 
     def __add_sb_connection(self, tile_from: Tile,
                             tile_to: Tile, track: int,
@@ -1147,12 +1149,12 @@ class SwitchBoxHelper:
             result.append((mod(track + 1, w), SwitchBoxSide.WEST,
                            track, SwitchBoxSide.SOUTH))
         return result
-    
+
     @staticmethod
     def get_tall_wilton_sb_wires(num_tracks: int, num_horizontal_tracks: int) -> List[Tuple[int,
-                                                           SwitchBoxSide,
-                                                           int,
-                                                           SwitchBoxSide]]:
+                                                                                            SwitchBoxSide,
+                                                                                            int,
+                                                                                            SwitchBoxSide]]:
         w = num_tracks
         result = []
         # t_i is defined as
@@ -1191,7 +1193,7 @@ class SwitchBoxHelper:
                           mod(track + 1, w), SwitchBoxSide.WEST))
             result.append((mod(track + 1, w), SwitchBoxSide.WEST,
                            track, SwitchBoxSide.SOUTH))
-            
+
         additional_result_0 = []
         # Add other actors
         for conn in result:
@@ -1199,7 +1201,7 @@ class SwitchBoxHelper:
             source_side = conn[1]
             dest_track = conn[2]
             dest_side = conn[3]
-            
+
             for additional_track in range(num_tracks, num_horizontal_tracks):
                 if source_side != SwitchBoxSide.SOUTH and source_side != SwitchBoxSide.NORTH:
                     if additional_track % num_tracks == source_track:
@@ -1208,7 +1210,6 @@ class SwitchBoxHelper:
                 if dest_side != SwitchBoxSide.SOUTH and dest_side != SwitchBoxSide.NORTH:
                     if additional_track % num_tracks == dest_track:
                         additional_result_0.append((source_track, source_side, additional_track, dest_side))
-        
 
         additional_result_1 = []
         for additional_track in range(num_tracks, num_horizontal_tracks):
@@ -1217,7 +1218,7 @@ class SwitchBoxHelper:
 
         result.extend(additional_result_0)
         result.extend(additional_result_1)
-        
+
         return result
 
     @staticmethod
@@ -1260,13 +1261,12 @@ class SwitchBoxHelper:
             result.append((track, SwitchBoxSide.NORTH,
                            track, SwitchBoxSide.SOUTH))
         return result
-    
 
     @staticmethod
     def get_tall_imran_sb_wires(num_tracks: int, num_horizontal_tracks: int) -> List[Tuple[int,
-                                                          SwitchBoxSide,
-                                                          int,
-                                                          SwitchBoxSide]]:
+                                                                                     SwitchBoxSide,
+                                                                                     int,
+                                                                                     SwitchBoxSide]]:
         w = num_tracks
         result = []
 
@@ -1301,7 +1301,6 @@ class SwitchBoxHelper:
                            track, SwitchBoxSide.NORTH))
             result.append((track, SwitchBoxSide.NORTH,
                            track, SwitchBoxSide.SOUTH))
-            
 
         additional_result_0 = []
         # Add other actors
@@ -1310,7 +1309,7 @@ class SwitchBoxHelper:
             source_side = conn[1]
             dest_track = conn[2]
             dest_side = conn[3]
-            
+
             for additional_track in range(num_tracks, num_horizontal_tracks):
                 if source_side != SwitchBoxSide.SOUTH and source_side != SwitchBoxSide.NORTH:
                     if additional_track % num_tracks == source_track:
@@ -1319,7 +1318,6 @@ class SwitchBoxHelper:
                 if dest_side != SwitchBoxSide.SOUTH and dest_side != SwitchBoxSide.NORTH:
                     if additional_track % num_tracks == dest_track:
                         additional_result_0.append((source_track, source_side, additional_track, dest_side))
-        
 
         additional_result_1 = []
         for additional_track in range(num_tracks, num_horizontal_tracks):
@@ -1333,9 +1331,9 @@ class SwitchBoxHelper:
 
     @staticmethod
     def get_imran_even_sb_wires(num_tracks: int) -> List[Tuple[int,
-                                                          SwitchBoxSide,
-                                                          int,
-                                                          SwitchBoxSide]]:
+                                                         SwitchBoxSide,
+                                                         int,
+                                                         SwitchBoxSide]]:
         w = num_tracks
         result = []
         # This method is used when the total number of tracks is even
@@ -1345,15 +1343,15 @@ class SwitchBoxHelper:
             # f_e1
             if track == 0:
                 result.append((track, SwitchBoxSide.WEST,
-                            1, SwitchBoxSide.NORTH))
+                               1, SwitchBoxSide.NORTH))
             elif track == (w - 1):
                 result.append((track, SwitchBoxSide.WEST,
-                            0, SwitchBoxSide.NORTH))
+                               0, SwitchBoxSide.NORTH))
             else:
                 result.append((track, SwitchBoxSide.WEST,
-                            mod(w - track, w), SwitchBoxSide.NORTH))
+                               mod(w - track, w), SwitchBoxSide.NORTH))
                 result.append((mod(w - track, w), SwitchBoxSide.NORTH,
-                            track, SwitchBoxSide.WEST))
+                               track, SwitchBoxSide.WEST))
             # f_e2
             result.append((track, SwitchBoxSide.NORTH,
                            mod(track + 1, w), SwitchBoxSide.EAST))
@@ -1380,13 +1378,12 @@ class SwitchBoxHelper:
             result.append((track, SwitchBoxSide.NORTH,
                            track, SwitchBoxSide.SOUTH))
         return result
-    
 
     @staticmethod
     def get_tall_imran_even_sb_wires(num_tracks: int) -> List[Tuple[int,
-                                                          SwitchBoxSide,
-                                                          int,
-                                                          SwitchBoxSide]]:
+                                                              SwitchBoxSide,
+                                                              int,
+                                                              SwitchBoxSide]]:
         w = num_tracks
         result = []
         # This method is used when the total number of tracks is even
@@ -1396,15 +1393,15 @@ class SwitchBoxHelper:
             # f_e1
             if track == 0:
                 result.append((track, SwitchBoxSide.WEST,
-                            1, SwitchBoxSide.NORTH))
+                               1, SwitchBoxSide.NORTH))
             elif track == (w - 1):
                 result.append((track, SwitchBoxSide.WEST,
-                            0, SwitchBoxSide.NORTH))
+                               0, SwitchBoxSide.NORTH))
             else:
                 result.append((track, SwitchBoxSide.WEST,
-                            mod(w - track, w), SwitchBoxSide.NORTH))
+                               mod(w - track, w), SwitchBoxSide.NORTH))
                 result.append((mod(w - track, w), SwitchBoxSide.NORTH,
-                            track, SwitchBoxSide.WEST))
+                               track, SwitchBoxSide.WEST))
             # f_e2
             result.append((track, SwitchBoxSide.NORTH,
                            mod(track + 1, w), SwitchBoxSide.EAST))
@@ -1430,7 +1427,6 @@ class SwitchBoxHelper:
                            track, SwitchBoxSide.NORTH))
             result.append((track, SwitchBoxSide.NORTH,
                            track, SwitchBoxSide.SOUTH))
-            
 
         additional_result_0 = []
         # Add other actors
@@ -1439,7 +1435,7 @@ class SwitchBoxHelper:
             source_side = conn[1]
             dest_track = conn[2]
             dest_side = conn[3]
-            
+
             for additional_track in range(num_tracks, num_horizontal_tracks):
                 if source_side != SwitchBoxSide.SOUTH and source_side != SwitchBoxSide.NORTH:
                     if additional_track % num_tracks == source_track:
@@ -1448,7 +1444,6 @@ class SwitchBoxHelper:
                 if dest_side != SwitchBoxSide.SOUTH and dest_side != SwitchBoxSide.NORTH:
                     if additional_track % num_tracks == dest_track:
                         additional_result_0.append((source_track, source_side, additional_track, dest_side))
-        
 
         additional_result_1 = []
         for additional_track in range(num_tracks, num_horizontal_tracks):
@@ -1470,28 +1465,25 @@ def create_name(name: str):
         name = name[:-1]
     return name
 
+
 if __name__ == "__main__":
     num_tracks = 5
     num_horizontal_tracks = 16
-    internal_wires_wilton= SwitchBoxHelper.get_wilton_sb_wires(num_tracks)
+    internal_wires_wilton = SwitchBoxHelper.get_wilton_sb_wires(num_tracks)
     internal_wires_tall_wilton = SwitchBoxHelper.get_tall_wilton_sb_wires(num_tracks, num_horizontal_tracks)
-    internal_wires_imran= SwitchBoxHelper.get_imran_sb_wires(num_tracks)
+    internal_wires_imran = SwitchBoxHelper.get_imran_sb_wires(num_tracks)
     internal_wires_tall_imran = SwitchBoxHelper.get_tall_imran_sb_wires(num_tracks, num_horizontal_tracks)
-
 
     def count_mux_inputs(tuple_list):
         mux_input_counts = defaultdict(lambda: 1)  # Dictionary to store mux_input counts. Add 1 by default for PE output
-        
+
         for item in tuple_list:
             track = f"{item[2]}_{item[3]}"  # Use 3rd and 4th elements
             mux_input_counts[track] += 1  # Increment count
 
         return dict(mux_input_counts)  # Convert defaultdict to a regular dict
-    
 
     print(count_mux_inputs(internal_wires_tall_imran))
-
-
 
     with open("imran.txt", "w") as file:
         for item in internal_wires_imran:
@@ -1502,8 +1494,8 @@ if __name__ == "__main__":
             file.write(str(item) + "\n")
 
     with open("wilton.txt", "w") as file:
-            for item in internal_wires_wilton:
-                file.write(str(item) + "\n")
+        for item in internal_wires_wilton:
+            file.write(str(item) + "\n")
 
     with open("tall_wilton.txt", "w") as file:
         for item in internal_wires_tall_wilton:

--- a/canal/global_signal.py
+++ b/canal/global_signal.py
@@ -174,7 +174,7 @@ def apply_global_parallel_meso_wiring(interconnect: Interconnect,
         # skip tiles with no config
         column = [entry for entry in column if "config" in entry.ports]
         # select which configuration controller is connected to that column
-        config_sel = int(x_coor/col_per_config)
+        config_sel = int(x_coor / col_per_config)
         # wire configuration ports to first tile in column
         interconnect.wire(interconnect.ports.config[config_sel],
                           column[0].ports.config)

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -268,7 +268,6 @@ class Interconnect(generator.Generator):
                             self.wire(p, tile.ports[sb_name + "_ready"])
                             self.__interface[ready_name] = sb_port
 
-
     def skip_margin_connection(self, tile):
         if self.give_north_io_sbs:
             return tile.switchbox.num_track > 0 and tile.y != 0
@@ -372,7 +371,6 @@ class Interconnect(generator.Generator):
                                 self.wire(tile_port[idx], next_port)
                                 if self.ready_valid:
                                     raise RuntimeError("Not supported")
-
 
     def __ground_ports(self):
         # this is a pass to ground every sb ports that's not connected
@@ -491,10 +489,12 @@ class Interconnect(generator.Generator):
 
         return res
 
-    def __set_fifo_mode(self, node: RegisterNode, start: bool, end: bool, use_non_split_fifos: bool = False, bogus_init: bool = False, bogus_init_num: int = 0):
+    def __set_fifo_mode(self, node: RegisterNode, start: bool, end: bool, use_non_split_fifos: bool = False,
+                        bogus_init: bool = False, bogus_init_num: int = 0):
         x, y = node.x, node.y
         tile = self.tile_circuits[(x, y)]
-        config_data = tile.configure_fifo(node, start, end, use_non_split_fifos=use_non_split_fifos, bogus_init=bogus_init, bogus_init_num=bogus_init_num)
+        config_data = tile.configure_fifo(node, start, end, use_non_split_fifos=use_non_split_fifos,
+                                          bogus_init=bogus_init, bogus_init_num=bogus_init_num)
         res = []
         for reg_addr, feat_addr, data in config_data:
             addr = self.get_config_addr(reg_addr, feat_addr, x, y)
@@ -502,7 +502,8 @@ class Interconnect(generator.Generator):
 
         return res
 
-    def get_bogus_init_config(self, node_track: str, x: int, y: int, id_to_name: Dict[str, str], reg_loc_to_id: Dict[Tuple[int, int], List[str]], id_to_metadata):
+    def get_bogus_init_config(self, node_track: str, x: int, y: int, id_to_name: Dict[str, str],
+                              reg_loc_to_id: Dict[Tuple[int, int], List[str]], id_to_metadata):
         print(f"Checking for bonus init config at {node_track} at {x}, {y}")
         print(reg_loc_to_id)
         matching_reg_list = reg_loc_to_id[(x, y)]
@@ -518,9 +519,9 @@ class Interconnect(generator.Generator):
                         return True
 
         return False
-    
 
-    def get_bogus_num_config(self, node_track: str, x: int, y: int, id_to_name: Dict[str, str], reg_loc_to_id: Dict[Tuple[int, int], List[str]], id_to_metadata):
+    def get_bogus_num_config(self, node_track: str, x: int, y: int, id_to_name: Dict[str, str],
+                             reg_loc_to_id: Dict[Tuple[int, int], List[str]], id_to_metadata):
         print(f"Checking for bonus init config at {node_track} at {x}, {y}")
         print(reg_loc_to_id)
         matching_reg_list = reg_loc_to_id[(x, y)]
@@ -573,7 +574,7 @@ class Interconnect(generator.Generator):
                             continue
                         # Case 1: Append candidate if current segment's last node matches candidate's first node.
                         if (isinstance(merged_nodes[-1], RegisterNode) and isinstance(candidate["nodes"][0], RegisterNode) and
-                            reg_key(merged_nodes[-1]) == reg_key(candidate["nodes"][0])):
+                                reg_key(merged_nodes[-1]) == reg_key(candidate["nodes"][0])):
                             merged_nodes.extend(candidate["nodes"][1:])  # skip joint REG node
                             used[j] = True
                             merged = True
@@ -581,7 +582,7 @@ class Interconnect(generator.Generator):
                             break
                         # Case 2: Prepend candidate if current segment's first node matches candidate's last node.
                         if (isinstance(merged_nodes[0], RegisterNode) and isinstance(candidate["nodes"][-1], RegisterNode) and
-                            reg_key(merged_nodes[0]) == reg_key(candidate["nodes"][-1])):
+                                reg_key(merged_nodes[0]) == reg_key(candidate["nodes"][-1])):
                             merged_nodes = candidate["nodes"][:-1] + merged_nodes  # skip joint REG node
                             used[j] = True
                             merged = True
@@ -604,7 +605,7 @@ class Interconnect(generator.Generator):
                     for idx in range(1, len(candidate["nodes"])):
                         node = candidate["nodes"][idx]
                         if isinstance(node, RegisterNode) and reg_key(node) == reg_key(branch_reg):
-                            candidate_prefix = candidate["nodes"][:idx+1]
+                            candidate_prefix = candidate["nodes"][:idx + 1]
                             # Choose the candidate with the longest prefix if multiple exist.
                             if best_prefix is None or len(candidate_prefix) > len(best_prefix):
                                 best_prefix = candidate_prefix
@@ -621,7 +622,7 @@ class Interconnect(generator.Generator):
         return new_routes
 
     def get_route_bitstream(self, routes: Dict[str, List[List[Node]]], use_fifo: bool = False,
-                            id_to_name = None, reg_loc_to_id = None, id_to_metadata = None):
+                            id_to_name=None, reg_loc_to_id=None, id_to_metadata=None):
 
         # TODO: For debugging only, can remove these when things get steady
         # with open("/aha/route_pre_merge.txt", "w") as file:
@@ -631,9 +632,9 @@ class Interconnect(generator.Generator):
         #             formatted_nodes = [f"({str(node)}, {node.x}, {node.y})" for node in segment]
         #             file.write(f"\n  Segment {i}: {' -> '.join(formatted_nodes)}")
 
-
         # Merge segments splitted by REG node if fifo is enabled
-        if use_fifo: routes = self.merge_segments_across_routes(routes)
+        if use_fifo:
+            routes = self.merge_segments_across_routes(routes)
 
         # TODO: For debugging only, can remove these when things get steady
         # with open("/aha/route_post_merge.txt", "w") as file:
@@ -658,7 +659,7 @@ class Interconnect(generator.Generator):
                         continue
                     if len(next_node.get_conn_in()) == 1:
                         # no mux created. skip
-                        continue      
+                        continue
                     configs = self.get_node_bitstream_config(pre_node, next_node,)
                     for addr, data in configs:
                         result.append((addr, data))
@@ -673,13 +674,15 @@ class Interconnect(generator.Generator):
                                     bogus_init_num = 0
                                 else:
                                     print("Have reg_loc_to_id - trying to configure FIFO")
-                                    bogus_init_num = self.get_bogus_num_config(pre_node.name, pre_node.x, pre_node.y, id_to_name, reg_loc_to_id, id_to_metadata)
-                                config = self.__set_fifo_mode(pre_node, start=False, end=False, use_non_split_fifos=True, bogus_init_num=bogus_init_num)
+                                    bogus_init_num = self.get_bogus_num_config(pre_node.name, pre_node.x,
+                                                                               pre_node.y, id_to_name, reg_loc_to_id, id_to_metadata)
+                                config = self.__set_fifo_mode(pre_node, start=False, end=False,
+                                                              use_non_split_fifos=True, bogus_init_num=bogus_init_num)
                                 result += config
 
-                # FIFO config for split FIFOs 
+                # FIFO config for split FIFOs
                 # Only turn reg pairs into FIFOs if using split FIFOs
-                if not(use_non_split_fifos):   
+                if not use_non_split_fifos:
                     if use_fifo and len(segment) >= 4:
                         reg_nodes = []
                         idx = 0
@@ -707,8 +710,12 @@ class Interconnect(generator.Generator):
                                     last_node_bogus_init = False
                                 else:
                                     print("Have reg_loc_to_id - trying to configure FIFO")
-                                    first_node_bogus_init = self.get_bogus_init_config(first_node.name, first_node.x, first_node.y, id_to_name, reg_loc_to_id, id_to_metadata)
-                                    last_node_bogus_init = self.get_bogus_init_config(last_node.name, last_node.x, last_node.y, id_to_name, reg_loc_to_id, id_to_metadata)
+                                    first_node_bogus_init = self.get_bogus_init_config(first_node.name, first_node.x,
+                                                                                       first_node.y, id_to_name, reg_loc_to_id,
+                                                                                       id_to_metadata)
+                                    last_node_bogus_init = self.get_bogus_init_config(last_node.name, last_node.x,
+                                                                                      last_node.y, id_to_name, reg_loc_to_id,
+                                                                                      id_to_metadata)
                                 print(f"First node: {first_node.name} - {first_node_bogus_init}")
                                 print(f"Last node: {last_node.name} - {last_node_bogus_init}")
 
@@ -1004,4 +1011,3 @@ class Interconnect(generator.Generator):
 
     def name(self):
         return "Interconnect"
-

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -573,16 +573,14 @@ class Interconnect(generator.Generator):
                         if not candidate["nodes"]:
                             continue
                         # Case 1: Append candidate if current segment's last node matches candidate's first node.
-                        if (isinstance(merged_nodes[-1], RegisterNode) and isinstance(candidate["nodes"][0], RegisterNode) and
-                                reg_key(merged_nodes[-1]) == reg_key(candidate["nodes"][0])):
+                        if (isinstance(merged_nodes[-1], RegisterNode) and isinstance(candidate["nodes"][0], RegisterNode) and reg_key(merged_nodes[-1]) == reg_key(candidate["nodes"][0])):
                             merged_nodes.extend(candidate["nodes"][1:])  # skip joint REG node
                             used[j] = True
                             merged = True
                             changed = True
                             break
                         # Case 2: Prepend candidate if current segment's first node matches candidate's last node.
-                        if (isinstance(merged_nodes[0], RegisterNode) and isinstance(candidate["nodes"][-1], RegisterNode) and
-                                reg_key(merged_nodes[0]) == reg_key(candidate["nodes"][-1])):
+                        if (isinstance(merged_nodes[0], RegisterNode) and isinstance(candidate["nodes"][-1], RegisterNode) and reg_key(merged_nodes[0]) == reg_key(candidate["nodes"][-1])):
                             merged_nodes = candidate["nodes"][:-1] + merged_nodes  # skip joint REG node
                             used[j] = True
                             merged = True
@@ -747,7 +745,8 @@ class Interconnect(generator.Generator):
                 for tag in tags:
                     if tag.tag_name == pnr_tag:
                         if 'P' in pnr_tag or 'p' in pnr_tag:
-                            result = core.get_config_bitstream(instr, active_core_ports=active_core_ports[instance_name], full_instance_name=full_instance_name)
+                            result = core.get_config_bitstream(instr, active_core_ports=active_core_ports[instance_name],
+                                                               full_instance_name=full_instance_name)
                         else:
                             result = core.get_config_bitstream(instr)
                         has_configured = True

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -491,10 +491,10 @@ class Interconnect(generator.Generator):
 
         return res
 
-    def __set_fifo_mode(self, node: RegisterNode, start: bool, end: bool):
+    def __set_fifo_mode(self, node: RegisterNode, start: bool, end: bool, bogus_init: bool = False):
         x, y = node.x, node.y
         tile = self.tile_circuits[(x, y)]
-        config_data = tile.configure_fifo(node, start, end)
+        config_data = tile.configure_fifo(node, start, end, bogus_init)
         res = []
         for reg_addr, feat_addr, data in config_data:
             addr = self.get_config_addr(reg_addr, feat_addr, x, y)
@@ -537,9 +537,9 @@ class Interconnect(generator.Generator):
                         for idx in range(0, len(reg_nodes), 2):
                             first_node = reg_nodes[idx]
                             last_node = reg_nodes[idx + 1]
-                            config = self.__set_fifo_mode(first_node, True, False)
+                            config = self.__set_fifo_mode(first_node, True, False, bogus_init=False)
                             result += config
-                            config = self.__set_fifo_mode(last_node, False, True)
+                            config = self.__set_fifo_mode(last_node, False, True, bogus_init=False)
                             result += config
 
         return result

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -544,7 +544,7 @@ class Interconnect(generator.Generator):
 
         return result
 
-    def configure_placement(self, x: int, y: int, instr, pnr_tag=None, node_num=None, active_core_ports=None):
+    def configure_placement(self, x: int, y: int, instr, pnr_tag=None, node_num=None, active_core_ports=None, full_instance_name=None):
         instance_name = f"{pnr_tag}{node_num}"
         tile = self.tile_circuits[(x, y)]
         core_: ConfigurableCore = None
@@ -565,7 +565,7 @@ class Interconnect(generator.Generator):
                 for tag in tags:
                     if tag.tag_name == pnr_tag:
                         if 'P' in pnr_tag or 'p' in pnr_tag:
-                            result = core.get_config_bitstream([instr, active_core_ports[instance_name]])
+                            result = core.get_config_bitstream([instr, active_core_ports[instance_name], full_instance_name])
                         else:
                             result = core.get_config_bitstream(instr)
                         has_configured = True

--- a/canal/interconnect.py
+++ b/canal/interconnect.py
@@ -503,14 +503,18 @@ class Interconnect(generator.Generator):
         return res
 
     def get_bogus_init_config(self, node_track: str, x: int, y: int, id_to_name: Dict[str, str], reg_loc_to_id: Dict[Tuple[int, int], List[str]], id_to_metadata):
+        print(f"Checking for bonus init config at {node_track} at {x}, {y}")
+        print(reg_loc_to_id)
         matching_reg_list = reg_loc_to_id[(x, y)]
         for reg in matching_reg_list:
             reg_full_name = id_to_name[reg]
             if node_track in reg_full_name:
                 if reg in id_to_metadata:
                     reg_metadata = id_to_metadata[reg]
+                    print(f"This regs metadata: {reg_metadata}")
                     extra_data_ = int(reg_metadata['extra_data'])
                     if extra_data_ == 1:
+                        print(f"Added bogus data!!!")
                         return True
 
         return False
@@ -621,11 +625,15 @@ class Interconnect(generator.Generator):
                             last_node = reg_nodes[idx + 1]
 
                             if reg_loc_to_id is None:
+                                print("No reg_loc_to_id provided. Skipping FIFO configuration")
                                 first_node_bogus_init = False
                                 last_node_bogus_init = False
                             else:
+                                print("Have reg_loc_to_id - trying to configure FIFO")
                                 first_node_bogus_init = self.get_bogus_init_config(first_node.name, first_node.x, first_node.y, id_to_name, reg_loc_to_id, id_to_metadata)
                                 last_node_bogus_init = self.get_bogus_init_config(last_node.name, last_node.x, last_node.y, id_to_name, reg_loc_to_id, id_to_metadata)
+                            print(f"First node: {first_node.name} - {first_node_bogus_init}")
+                            print(f"Last node: {last_node.name} - {last_node_bogus_init}")
 
                             config = self.__set_fifo_mode(first_node, True, False, bogus_init=first_node_bogus_init)
                             result += config

--- a/canal/logic.py
+++ b/canal/logic.py
@@ -115,7 +115,8 @@ class RegFIFO(Generator):
 
         self._num_items = self.var("num_items", clog2(self.depth) + 1)
         # self.wire(self._full, (self._wr_ptr + 1) == self._rd_ptr)
-        self.wire(self._full, self._num_items == self.depth)
+        # self.wire(self._full, (self._num_items == self.depth) | ~(~self._flush & self._clk_en))
+        self.wire(self._full, (self._num_items == self.depth) | self._flush)
         # Experiment to cover latency
         self.wire(self._almost_full,
                   self._num_items >= (self.depth - self.almost_full_diff))
@@ -239,7 +240,8 @@ class RegFIFO(Generator):
 
     @always_comb
     def valid_comb(self):
-        self._valid = ((~self._empty) | self._passthru)
+        # self._valid = ((~self._empty & ~self._flush & self._clk_en) | self._passthru)
+        self._valid = ((~self._empty & ~self._flush) | self._passthru)
 
     @always_ff((posedge, "clk"), (negedge, "rst_n"))
     def set_num_items(self):

--- a/canal/logic.py
+++ b/canal/logic.py
@@ -40,7 +40,7 @@ class RegFIFO(Generator):
         self._clk = self.clock("clk")
         self._rst_n = self.reset("rst_n")
         self._clk_en = self.clock_en("clk_en", 1)
-
+       
         # INPUTS
         self._data_in = self.input("data_in",
                                    self.data_width,
@@ -285,7 +285,8 @@ class SplitFifo(Generator):
         fifo_en = self.input("fifo_en", 1)
 
         # need to add clock enables
-        clk_en = self.clock_en("clk_en")
+        # clk_en = self.clock_en("clk_en")
+        clk_en = self.input("clk_en", 1)
 
         self.wire(ready_in, ready1.and_(~start_fifo))
         self.wire(ready0, kratos.ternary(fifo_en, empty.or_(ready_in), clk_en))

--- a/canal/logic.py
+++ b/canal/logic.py
@@ -40,7 +40,7 @@ class RegFIFO(Generator):
         self._clk = self.clock("clk")
         self._rst_n = self.reset("rst_n")
         self._clk_en = self.clock_en("clk_en", 1)
-       
+
         # INPUTS
         self._data_in = self.input("data_in",
                                    self.data_width,
@@ -289,9 +289,9 @@ class SplitFifo(Generator):
         clk_en = self.input("clk_en", 1)
 
         self.wire(ready_in, ready1.and_(~start_fifo))
-        self.wire(ready0, kratos.ternary(fifo_en, empty.or_(ready_in), clk_en))
+        self.wire(ready0, kratos.ternary(fifo_en, (empty.or_(ready_in)) & ~flush & clk_en, clk_en))
         self.wire(valid_in, valid0.and_(~end_fifo))
-        self.wire(valid1, kratos.ternary(fifo_en, (~empty).or_(valid_in), clk_en))
+        self.wire(valid1, kratos.ternary(fifo_en, ((~empty).or_(valid_in)) & ~flush & clk_en, clk_en))
 
         self.wire(data_out, kratos.ternary(empty.and_(fifo_en), data_in, value))
 
@@ -348,8 +348,8 @@ class FifoRegWrapper(GemstoneGenerator):
             clk=magma.In(magma.Clock),
             CE=magma.In(magma.Enable),
             ASYNCRESET=magma.In(magma.AsyncReset),
-            
-            # MO: Flush signal HACK 
+
+            # MO: Flush signal HACK
             flush=magma.In(magma.Bit),
             bogus_init=magma.In(magma.Bit),
 

--- a/canal/logic.py
+++ b/canal/logic.py
@@ -57,7 +57,6 @@ class RegFIFO(Generator):
         # control whether to function as a pipeline register or not
         self._fifo_en = self.input("fifo_en", 1)
 
-        # MO: Flush signal HACK
         self._flush = self.input("flush", 1)
         self._bogus_init_num = self.input("bogus_init_num", 2)
 
@@ -114,7 +113,6 @@ class RegFIFO(Generator):
 
         self._num_items = self.var("num_items", clog2(self.depth) + 1)
         # self.wire(self._full, (self._wr_ptr + 1) == self._rd_ptr)
-        # self.wire(self._full, (self._num_items == self.depth) | ~(~self._flush & self._clk_en))
         self.wire(self._full, (self._num_items == self.depth) | self._flush | ~self._clk_en)
         # self.wire(self._full, (self._num_items == self.depth) | self._flush)
         # Experiment to cover latency
@@ -289,7 +287,6 @@ class SplitFifo(Generator):
         clk = self.clock("clk")
         rst = self.reset("rst")
 
-        # MO: Flush signal HACK
         flush = self.input("flush", 1)
         bogus_init = self.input("bogus_init", 1)
 
@@ -383,10 +380,7 @@ class FifoRegWrapper(GemstoneGenerator):
             clk=magma.In(magma.Clock),
             CE=magma.In(magma.Enable),
             ASYNCRESET=magma.In(magma.AsyncReset),
-
-            # MO: Flush signal HACK
             flush=magma.In(magma.Bit),
-
             valid_in=magma.In(magma.Bit),
             valid_out=magma.Out(magma.Bit),
             ready_in=magma.In(magma.Bit),
@@ -411,7 +405,6 @@ class FifoRegWrapper(GemstoneGenerator):
         self.wire(self.ports.CE, self.__circuit.ports.clk_en[0])
         self.wire(self.ports.fifo_en, self.__circuit.ports.fifo_en[0])
 
-        # MO: Flush signal HACK
         self.wire(self.ports.flush, self.__circuit.ports.flush[0])
 
         if self.use_non_split_fifos:

--- a/canal/logic.py
+++ b/canal/logic.py
@@ -258,6 +258,9 @@ class SplitFifo(Generator):
         clk = self.clock("clk")
         rst = self.reset("rst")
 
+        # MO: Flush signal HACK
+        flush = self.input("flush", 1)
+
         data_in = self.input("data_in", width)
         data_out = self.output("data_out", width)
 
@@ -336,6 +339,10 @@ class FifoRegWrapper(GemstoneGenerator):
             clk=magma.In(magma.Clock),
             CE=magma.In(magma.Enable),
             ASYNCRESET=magma.In(magma.AsyncReset),
+            
+            # MO: Flush signal HACK 
+            flush=magma.In(magma.Bit),
+
             valid_in=magma.In(magma.Bit),
             valid_out=magma.Out(magma.Bit),
             ready_in=magma.In(magma.Bit),
@@ -344,12 +351,13 @@ class FifoRegWrapper(GemstoneGenerator):
             start_fifo=magma.In(magma.Bit),
             end_fifo=magma.In(magma.Bit)
         )
-
+        
         self.wire(self.ports.I, self.__circuit.ports.data_in)
         self.wire(self.ports.O, self.__circuit.ports.data_out)
         self.wire(self.ports.clk, self.__circuit.ports.clk)
         self.wire(self.ports.CE, self.__circuit.ports.clk_en[0])
         self.wire(self.ports.fifo_en, self.__circuit.ports.fifo_en[0])
+        self.wire(self.ports.flush, self.__circuit.ports.flush[0])
         self.wire(self.ports.ASYNCRESET,
                   self.__circuit.ports.rst)
         self.wire(self.ports.valid_in, self.__circuit.ports.valid0[0])

--- a/canal/util.py
+++ b/canal/util.py
@@ -104,7 +104,7 @@ def create_uniform_interconnect(width: int,
 
     interconnect_x_min = num_fabric_cols_removed if num_fabric_cols_removed > 0 else x_min
     interconnect_x_max = x_max
-    interconnect_y_min = y_min-1 if give_north_io_sbs else y_min
+    interconnect_y_min = y_min - 1 if give_north_io_sbs else y_min
     interconnect_y_max = y_max
 
     # create tiles and set cores
@@ -122,12 +122,12 @@ def create_uniform_interconnect(width: int,
                 sb = ImranSwitchBox(x, y, num_track, track_width)
             else:
                 raise NotImplementedError(sb_type)
-            
+
             tile_circuit = Tile(x, y, track_width, sb, tile_height)
 
             interconnect.add_tile(tile_circuit)
             core = column_core_fn(x, y)
- 
+
             core_interface = CoreInterface(core)
             interconnect.set_core(x, y, core_interface)
 
@@ -136,7 +136,7 @@ def create_uniform_interconnect(width: int,
                 additional_core_interface = CoreInterface(additional_core)
                 tile_circuit.add_additional_core(additional_core_interface,
                                                  CoreConnectionType.SB | CoreConnectionType.CB)
-                
+
     # Handle North I/O if giving north I/O SB
     if give_north_io_sbs:
         for x in range(x_min, x_max + 1):
@@ -144,10 +144,10 @@ def create_uniform_interconnect(width: int,
                 # skip if the tiles is already created
                 tile = interconnect.get_tile(x, y)
                 if tile is not None:
-                    continue 
+                    continue
                 # compute the number of tracks
                 num_track = compute_num_tracks(x_min, y_min,
-                                            x, y, track_info)
+                                               x, y, track_info)
                 # create switch based on the type passed in
                 if sb_type == SwitchBoxType.Disjoint:
                     if tall_north_io_sbs:
@@ -156,24 +156,26 @@ def create_uniform_interconnect(width: int,
 
                 elif sb_type == SwitchBoxType.Wilton:
                     if tall_north_io_sbs:
-                        sb = TallWiltonSwitchBox(x, y, num_track, num_tall_sb_horizontal_tracks, track_width)
+                        sb = TallWiltonSwitchBox(x, y, num_track,
+                                                 num_tall_sb_horizontal_tracks, track_width)
                     else:
                         sb = WiltonSwitchBox(x, y, num_track, track_width)
 
                 elif sb_type == SwitchBoxType.Imran:
                     if tall_north_io_sbs:
-                        sb = TallImranSwitchBox(x, y, num_track, num_tall_sb_horizontal_tracks, track_width)
+                        sb = TallImranSwitchBox(x, y, num_track,
+                                                num_tall_sb_horizontal_tracks, track_width)
                     else:
                         sb = ImranSwitchBox(x, y, num_track, track_width)
 
                 else:
                     raise NotImplementedError(sb_type)
-                
+
                 tile_circuit = Tile(x, y, track_width, sb, tile_height, isTallTile=tall_north_io_sbs)
 
                 interconnect.add_tile(tile_circuit)
                 core = column_core_fn(x, y)
-    
+
                 core_interface = CoreInterface(core)
                 interconnect.set_core(x, y, core_interface)
 
@@ -181,22 +183,21 @@ def create_uniform_interconnect(width: int,
                 if additional_core is not None:
                     additional_core_interface = CoreInterface(additional_core)
                     tile_circuit.add_additional_core(additional_core_interface,
-                                                    CoreConnectionType.SB | CoreConnectionType.CB)
-                    
+                                                     CoreConnectionType.SB | CoreConnectionType.CB)
+
     # Handle South Matrix unit I/O tiles if they exist
     if using_matrix_unit and IOSide.South in io_sides:
         for x in range(x_min, x_max + 1):
-            for y in range(y_max+1, height):
+            for y in range(y_max + 1, height):
                 core = column_core_fn(x, y)
                 # if core is None:
                 #     continue
-            
+
                 sb = SwitchBox(x, y, 0, track_width, [])
                 tile_circuit = Tile(x, y, track_width, sb, tile_height)
-                interconnect.add_tile(tile_circuit)   
+                interconnect.add_tile(tile_circuit)
                 core_interface = CoreInterface(core)
                 interconnect.set_core(x, y, core_interface)
-
 
     # create tiles without SB
     for x in range(width):
@@ -206,10 +207,10 @@ def create_uniform_interconnect(width: int,
             if tile is not None:
                 continue
             core = column_core_fn(x, y)
-           
+
             sb = SwitchBox(x, y, 0, track_width, [])
             tile_circuit = Tile(x, y, track_width, sb, tile_height)
-            interconnect.add_tile(tile_circuit)   
+            interconnect.add_tile(tile_circuit)
             core_interface = CoreInterface(core)
             interconnect.set_core(x, y, core_interface)
 
@@ -219,7 +220,6 @@ def create_uniform_interconnect(width: int,
     for port_name in port_names:
         conns = port_connections[port_name]
         interconnect.set_core_connection_all(port_name, conns)
-
 
     if inter_core_connection is not None:
         interconnect.set_inter_core_connection(inter_core_connection)
@@ -232,31 +232,31 @@ def create_uniform_interconnect(width: int,
     for track_len in track_lens:
         for _ in range(track_info[track_len]):
             # This function connects neighboring switchboxes to each other (North, south east, west)
-            # Pass 1: Contiguous tile array fabric 
+            # Pass 1: Contiguous tile array fabric
             interconnect.connect_switchbox(interconnect_x_min, interconnect_y_min, interconnect_x_max,
                                            interconnect_y_max,
                                            track_len,
                                            current_track,
                                            InterconnectPolicy.Ignore)
 
-             # (Optional) Pass 2: For any unconnected I/O tiles due to "num_fabric_cols_removed" > 0
+            # (Optional) Pass 2: For any unconnected I/O tiles due to "num_fabric_cols_removed" > 0
             if give_north_io_sbs and num_fabric_cols_removed > 0:
                 interconnect.connect_switchbox(x_min, interconnect_y_min, interconnect_x_max,
-                                            interconnect_y_min,
-                                            track_len,
-                                            current_track,
-                                            InterconnectPolicy.Ignore)
+                                               interconnect_y_min,
+                                               track_len,
+                                               current_track,
+                                               InterconnectPolicy.Ignore)
             current_track += 1
 
-    # connect the tall switchboxes if they exist 
+    # connect the tall switchboxes if they exist
     if give_north_io_sbs and tall_north_io_sbs:
         for current_track in range(num_track, num_tall_sb_horizontal_tracks):
-            interconnect.connect_switchbox(x_min, interconnect_y_min, interconnect_x_max,
-                                                interconnect_y_min,
-                                                track_len,
-                                                current_track,
-                                                InterconnectPolicy.Ignore, isTallConnection=True)
-
+            interconnect.connect_switchbox(x_min, interconnect_y_min,
+                                           interconnect_x_max,
+                                           interconnect_y_min,
+                                           track_len,
+                                           current_track,
+                                           InterconnectPolicy.Ignore, isTallConnection=True)
 
     # insert io
     connect_io(interconnect, io_conn["in"], io_conn["out"], io_sides, give_north_io_sbs, num_fabric_cols_removed)
@@ -269,10 +269,11 @@ def create_uniform_interconnect(width: int,
 
         pipeline_regs_to_add = pipeline_reg.copy()
         if tile.isTallTile:
-            for track in range(tile.switchbox.num_track, tile.switchbox.num_horizontal_track):
+            for track in range(tile.switchbox.num_track,
+                               tile.switchbox.num_horizontal_track):
                 pipeline_regs_to_add.append((track, SwitchBoxSide.WEST))
                 pipeline_regs_to_add.append((track, SwitchBoxSide.EAST))
-        
+
         for track, side in pipeline_regs_to_add:
             if tile.switchbox is None or tile.switchbox.num_track == 0:
                 continue
@@ -281,10 +282,11 @@ def create_uniform_interconnect(width: int,
 
     return interconnect
 
-# This function connects tiles that are at the edge to nearby tiles in the 
-# appropriate direction (North, west, east, or south neighbor). Makes this 
+
+# This function connects tiles that are at the edge to nearby tiles in the
+# appropriate direction (North, west, east, or south neighbor). Makes this
 # connection in the interconnect graph. Actual magma connection is done in
-# a separate pass. 
+# a separate pass.
 def connect_io(interconnect: InterconnectGraph,
                input_port_conn: Dict[str, List[int]],
                output_port_conn: Dict[str, List[int]],
@@ -300,7 +302,7 @@ def connect_io(interconnect: InterconnectGraph,
 
     interconnect_x_min = num_fabric_cols_removed if num_fabric_cols_removed > 0 else x_min
     interconnect_x_max = x_max
-    interconnect_y_min = y_min-1 if give_north_io_sbs else y_min
+    interconnect_y_min = y_min - 1 if give_north_io_sbs else y_min
     interconnect_y_max = y_max
 
     # compute tiles and sides
@@ -309,17 +311,18 @@ def connect_io(interconnect: InterconnectGraph,
             if x in range(interconnect_x_min, interconnect_x_max + 1) and \
                     y in range(interconnect_y_min, interconnect_y_max + 1):
                 continue
-           
+
             # make sure that these margins tiles have empty switch boxes
             tile = interconnect[(x, y)]
 
             if tile.core.core is None:
                 continue
 
-            # This means the tile isn't an I/O that needs to be connected using this function 
+            # This means the tile isn't an I/O that needs to be connected using this function
             if tile.switchbox.num_track > 0:
-                continue 
-            #assert tile.switchbox.num_track == 0
+                continue
+
+            # assert tile.switchbox.num_track == 0
 
             # compute the nearby tile
             if x in range(0, interconnect_x_min):
@@ -348,7 +351,6 @@ def connect_io(interconnect: InterconnectGraph,
                                                        SwitchBoxIO.SB_OUT)
                             sb_node.add_edge(port_node)
 
-            
             for output_port, conn in output_port_conn.items():
                 # output is IO to fabric
                 if output_port in tile.ports:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ max-line-length = 140
 
 # E741: do not use variables named ‘l’, ‘O’, or ‘I’
 # We ignore this because I and O is currently idiomatic magma for port names
-ignore = E741,E501
+ignore = E741, E501
 
 [tool:pytest]
 codestyle_max_line_length = 80

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pycodestyle]
-max-line-length = 80
+max-line-length = 140
 
 # E741: do not use variables named ‘l’, ‘O’, or ‘I’
 # We ignore this because I and O is currently idiomatic magma for port names

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ max-line-length = 140
 
 # E741: do not use variables named ‘l’, ‘O’, or ‘I’
 # We ignore this because I and O is currently idiomatic magma for port names
-ignore = E741
+ignore = E741,E501
 
 [tool:pytest]
 codestyle_max_line_length = 80


### PR DESCRIPTION
1. Wire flush signal to interconnect FIFOs
2.  Add HW and SW support to optionally initialize interconnect FIFOs non-empty. This is needed to run some dense apps in ready-valid mode
3. Add proper ready-valid loopback logic to interconnect FIFOs in switch boxes 

Corresponding AHA PR: https://github.com/StanfordAHA/aha/pull/2034